### PR TITLE
Add eks:DescribeAddonConfiguration to the boot node role

### DIFF
--- a/templates/ibm-liberty-iam-role.template.yaml
+++ b/templates/ibm-liberty-iam-role.template.yaml
@@ -87,6 +87,11 @@ Resources:
                   - !Sub arn:${AWS::Partition}:eks:*:${AWS::AccountId}:fargateprofile/*/*/*
               - Effect: Allow
                 Action:
+                  - eks:DescribeAddonConfiguration
+                Resource:
+                  - !Sub arn:${AWS::Partition}:eks:*:${AWS::AccountId}:*
+              - Effect: Allow
+                Action:
                   - ssm:GetParameter
                   - ssm:GetParameters
                   - ssm:PutParameter


### PR DESCRIPTION
The EKS cluster fails to spin up because of a missing permission in the policy. I am adding the resource section in the proposed update exactly as shown in the error below:
api error AccessDeniedException: User: arn:aws:sts::XXXXXXXXXXXX:assumed-role/ibm-liberty-ibmlibertyekscluster-us-east-2-role/i-XXXXXXXXXXXXXXXX is not authorized to perform: eks:DescribeAddonConfigurationon resource: arn:aws:eks:us-east-2:XXXXXXXXXXXX:*